### PR TITLE
Update C++ standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.5)
 set(project_name "f0plugins")
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_modules ${CMAKE_MODULE_PATH})
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 ####################################################################################################
 # load modules


### PR DESCRIPTION
This matches the C++ version used in mainline SuperCollider to make sure it doesn't fail when building (because SC uses templates etc., more modern features beyond C++11)